### PR TITLE
通知テーブルにlike数・retweet数を保存するよう修正

### DIFF
--- a/lambda_functions/event_bridge/tweet_monitor_batch.py
+++ b/lambda_functions/event_bridge/tweet_monitor_batch.py
@@ -109,9 +109,12 @@ def save_notifications_for_tweets(tweets, slack_ch, notifications_repo):
     for tweet in tweets:
         tweet_uid = str(tweet.id) if hasattr(tweet, 'id') else tweet.get('id')
         tweet_url = f"https://twitter.com/i/web/status/{tweet_uid}"
+        metrics = tweet.public_metrics if hasattr(tweet, 'public_metrics') else tweet.get('public_metrics', {})
+        like_count = metrics.get('like_count', 0)
+        retweet_count = metrics.get('retweet_count', 0)
         if not notifications_repo.exists(tweet_uid, slack_ch):
-            notifications_repo.put(tweet_uid, tweet_url, slack_ch)
-            print(f"[BatchWatcher] 通知テーブルに保存: {tweet_uid} {tweet_url} {slack_ch}")
+            notifications_repo.put(tweet_uid, tweet_url, slack_ch, like_count, retweet_count)
+            print(f"[BatchWatcher] 通知テーブルに保存: {tweet_uid} {tweet_url} {slack_ch} {like_count} {retweet_count}")
         else:
             print(f"[BatchWatcher] 既に通知済み: {tweet_uid} {slack_ch}")
 

--- a/repositories/notifications_repository.py
+++ b/repositories/notifications_repository.py
@@ -1,6 +1,5 @@
 import os
 import boto3
-from datetime import datetime, timezone
 
 class NotificationsRepository:
     def __init__(self, table_name=None):
@@ -12,11 +11,13 @@ class NotificationsRepository:
         resp = self.table.get_item(Key={"tweet_uid": tweet_uid, "slack_ch": slack_ch})
         return 'Item' in resp
 
-    def put(self, tweet_uid, tweet_url, slack_ch, slack_message_ts=None):
+    def put(self, tweet_uid, tweet_url, slack_ch, like_count, retweet_count, slack_message_ts=None):
         item = {
             "tweet_uid": tweet_uid,
             "tweet_url": tweet_url,
-            "slack_ch": slack_ch
+            "slack_ch": slack_ch,
+            "like_count": like_count,
+            "retweet_count": retweet_count
         }
         if slack_message_ts is not None:
             item["slack_message_ts"] = slack_message_ts

--- a/tests/repositories/test_notifications_repository.py
+++ b/tests/repositories/test_notifications_repository.py
@@ -16,10 +16,12 @@ def test_exists_and_put():
         assert repo.exists('2', 'ch') is False
 
         # put: put_itemが呼ばれること
-        repo.put('3', 'url', 'ch', '2025-01-01T00:00:00Z')
+        repo.put('3', 'url', 'ch', 123, 45, '2025-01-01T00:00:00Z')
         mock_table.put_item.assert_called_with(Item={
             'tweet_uid': '3',
             'tweet_url': 'url',
             'slack_ch': 'ch',
+            'like_count': 123,
+            'retweet_count': 45,
             'slack_message_ts': '2025-01-01T00:00:00Z'
         })


### PR DESCRIPTION
tweet_monitor_batch経由で通知テーブルにlike_count/retweet_countを保存するようにしました。
- NotificationsRepository.putの引数追加
- バッチ本体の保存処理修正
- テスト修正