### PR TITLE
chore: LIKE_THRESHOLD, RETWEET_THRESHOLD環境変数の利用・定義を完全削除

### DIFF
--- a/lambda_functions/event_bridge/tweet_monitor_batch.py
+++ b/lambda_functions/event_bridge/tweet_monitor_batch.py
@@ -1,13 +1,13 @@
 from repositories.settings_repository import SettingsRepository
 from repositories.notifications_repository import NotificationsRepository
 from repositories.x_credential_settings_repository import XCredentialSettingsRepository
+import tweepy
 # .env自動ロード（ローカル開発用）
 try:
     from dotenv import load_dotenv
     load_dotenv()
 except ImportError:
     pass
-import tweepy
 
 def get_twitter_client():
     """

--- a/template.yaml
+++ b/template.yaml
@@ -151,8 +151,6 @@ Resources:
               - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TweetWacherSettingsTable}/index/publication_status-index
       Environment:
         Variables:
-          LIKE_THRESHOLD: "5"
-          RETWEET_THRESHOLD: "1"
           SLACK_SIGNING_SECRET: !Ref SlackSigningSecret
           SLACK_BOT_TOKEN: !Ref SlackBotToken
       Events:


### PR DESCRIPTION
LIKE_THRESHOLD, RETWEET_THRESHOLDの環境変数による閾値取得・定義を完全に削除しました。

- Lambda, template.yaml から該当箇所を除去
- 閾値はDynamoDB設定のみで管理

ご確認よろしくお願いします。