### PR TITLE
feat: TweetWacherSettingsTableにlastExecutedTimeカラム追加・バッチ/REST API対応

### DIFF
--- a/lambda_functions/api_gateway/setting/list.py
+++ b/lambda_functions/api_gateway/setting/list.py
@@ -1,5 +1,19 @@
 import logging
 from repositories.settings_repository import SettingsRepository
+from datetime import datetime, timezone, timedelta
+
+
+def format_jst(dt_str):
+    if not dt_str:
+        return "-"
+    try:
+        # ISO8601文字列をパース
+        dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+        # JSTへ変換
+        jst = dt.astimezone(timezone(timedelta(hours=9)))
+        return jst.strftime("%Y/%m/%d %H:%M:%S")
+    except Exception:
+        return dt_str  # パース失敗時はそのまま返す
 
 
 def get_setting(args, integration):
@@ -14,7 +28,7 @@ def get_setting(args, integration):
                 )
             msg = "[list] アクティブな設定一覧:\n" + "\n".join(
                 [
-                    f"{item['id']}: {item['keyword']} {item['slack_ch']} like: {item.get('like_threshold', '-')}, rt: {item.get('retweet_threshold', '-')}"
+                    f"{item['id']}: {item['keyword']} {item['slack_ch']} like: {item.get('like_threshold', '-')}, rt: {item.get('retweet_threshold', '-')} lastExecuted: {format_jst(item.get('lastExecutedTime'))}"
                     for item in items
                 ]
             )
@@ -26,7 +40,7 @@ def get_setting(args, integration):
                 return integration.build_response("[list] 設定が1件もありません")
             msg = "[list] 全設定一覧:\n" + "\n".join(
                 [
-                    f"{item['id']}: {item['keyword']} {item['slack_ch']} (publication_status: {item.get('publication_status', 'unknown')}) like: {item.get('like_threshold', '-')}, rt: {item.get('retweet_threshold', '-')}"
+                    f"{item['id']}: {item['keyword']} {item['slack_ch']} (publication_status: {item.get('publication_status', 'unknown')}) like: {item.get('like_threshold', '-')}, rt: {item.get('retweet_threshold', '-')} lastExecuted: {format_jst(item.get('lastExecutedTime'))}"
                     for item in items
                 ]
             )

--- a/lambda_functions/event_bridge/tweet_monitor_batch.py
+++ b/lambda_functions/event_bridge/tweet_monitor_batch.py
@@ -213,6 +213,7 @@ def lambda_handler(event, context):
     print(f"[BatchWatcher] 有効な設定: {valid_settings}")
     notifications_repo = NotificationsRepository()
     slack_integration = SlackIntegration()
+
     # lastExecutedTimeがnull→古い順でソート
     def sort_key(setting):
         t = setting.get("lastExecutedTime")
@@ -223,6 +224,7 @@ def lambda_handler(event, context):
         except Exception:
             return (1, None)
         return (1, dt)
+
     valid_settings = sorted(valid_settings, key=sort_key)
     for setting in valid_settings:
         process_setting_for_notification(

--- a/lambda_functions/event_bridge/tweet_monitor_batch.py
+++ b/lambda_functions/event_bridge/tweet_monitor_batch.py
@@ -5,6 +5,7 @@ from integration.slack_integration import SlackIntegration
 import json
 import urllib.request
 import urllib.parse
+from datetime import datetime, timezone, timedelta
 
 # .env自動ロード（ローカル開発用）
 try:
@@ -189,6 +190,14 @@ def process_setting_for_notification(
     save_notifications_for_tweets(
         filtered_tweets, slack_ch, notifications_repo, slack_integration
     )
+    # 正常に処理が終わったらlastExecutedTimeをJSTのISO8601で保存
+    try:
+        settings_repo = SettingsRepository()
+        now_jst = datetime.now(timezone(timedelta(hours=9))).isoformat()
+        settings_repo.update_last_executed_time_by_id(setting["id"], now_jst)
+        print(f"[BatchWatcher] lastExecutedTime更新: {setting['id']} {now_jst}")
+    except Exception as e:
+        print(f"[BatchWatcher] lastExecutedTime更新失敗: {e}")
 
 
 def lambda_handler(event, context):
@@ -204,6 +213,17 @@ def lambda_handler(event, context):
     print(f"[BatchWatcher] 有効な設定: {valid_settings}")
     notifications_repo = NotificationsRepository()
     slack_integration = SlackIntegration()
+    # lastExecutedTimeがnull→古い順でソート
+    def sort_key(setting):
+        t = setting.get("lastExecutedTime")
+        if not t:
+            return (0, None)
+        try:
+            dt = datetime.fromisoformat(t.replace("Z", "+00:00"))
+        except Exception:
+            return (1, None)
+        return (1, dt)
+    valid_settings = sorted(valid_settings, key=sort_key)
     for setting in valid_settings:
         process_setting_for_notification(
             setting, bearer_token, notifications_repo, slack_integration

--- a/repositories/settings_repository.py
+++ b/repositories/settings_repository.py
@@ -42,6 +42,7 @@ class SettingsRepository:
             "keyword": keyword,
             "slack_ch": slack_ch,
             "publication_status": publication_status,
+            "lastExecutedTime": None,
         }
         if like_threshold is not None:
             item["like_threshold"] = int(like_threshold)
@@ -117,6 +118,15 @@ class SettingsRepository:
                 int(retweet_threshold) if retweet_threshold is not None else None
             )
         }
+        return self.table.update_item(
+            Key={"id": id},
+            UpdateExpression=update_expr,
+            ExpressionAttributeValues=expr_attr,
+        )
+
+    def update_last_executed_time_by_id(self, id, last_executed_time):
+        update_expr = "SET lastExecutedTime = :lastExecutedTime"
+        expr_attr = {":lastExecutedTime": last_executed_time}
         return self.table.update_item(
             Key={"id": id},
             UpdateExpression=update_expr,

--- a/template.yaml
+++ b/template.yaml
@@ -145,7 +145,7 @@ Resources:
         Schedule:
           Type: Schedule
           Properties:
-            Schedule: rate(1 hour)
+            Schedule: rate(20 minutes)
 
   NotifySlackFunction:
     Type: AWS::Serverless::Function

--- a/tests/lambda_functions/api_gateway/setting/test_list.py
+++ b/tests/lambda_functions/api_gateway/setting/test_list.py
@@ -15,7 +15,16 @@ def integration():
 def test_list_setting_active(monkeypatch, integration):
     class DummyRepo:
         def list_valid_settings(self):
-            return {"Items": [{"id": "id1", "keyword": "kw", "slack_ch": "#ch", "lastExecutedTime": "2024-06-13T12:34:56+09:00"}]}
+            return {
+                "Items": [
+                    {
+                        "id": "id1",
+                        "keyword": "kw",
+                        "slack_ch": "#ch",
+                        "lastExecutedTime": "2024-06-13T12:34:56+09:00",
+                    }
+                ]
+            }
 
     monkeypatch.setattr(list_mod, "SettingsRepository", lambda: DummyRepo())
     args = []

--- a/tests/lambda_functions/api_gateway/setting/test_list.py
+++ b/tests/lambda_functions/api_gateway/setting/test_list.py
@@ -15,12 +15,13 @@ def integration():
 def test_list_setting_active(monkeypatch, integration):
     class DummyRepo:
         def list_valid_settings(self):
-            return {"Items": [{"id": "id1", "keyword": "kw", "slack_ch": "#ch"}]}
+            return {"Items": [{"id": "id1", "keyword": "kw", "slack_ch": "#ch", "lastExecutedTime": "2024-06-13T12:34:56+09:00"}]}
 
     monkeypatch.setattr(list_mod, "SettingsRepository", lambda: DummyRepo())
     args = []
     resp = list_mod.get_setting(args, integration)
     assert "アクティブな設定一覧" in resp
+    assert "lastExecuted: 2024/06/13 12:34:56" in resp
 
 
 def test_list_setting_all(monkeypatch, integration):
@@ -33,6 +34,7 @@ def test_list_setting_all(monkeypatch, integration):
                         "keyword": "kw",
                         "slack_ch": "#ch",
                         "publication_status": "active",
+                        "lastExecutedTime": "2024-06-13T12:34:56+09:00",
                     }
                 ]
             }
@@ -41,6 +43,7 @@ def test_list_setting_all(monkeypatch, integration):
     args = ["-a"]
     resp = list_mod.get_setting(args, integration)
     assert "全設定一覧" in resp
+    assert "lastExecuted: 2024/06/13 12:34:56" in resp
 
 
 def test_list_setting_param_error(monkeypatch, integration):

--- a/tests/repositories/test_settings_repository.py
+++ b/tests/repositories/test_settings_repository.py
@@ -18,6 +18,7 @@ def test_put_get_delete_update():
                 "keyword": "kw",
                 "slack_ch": "ch",
                 "publication_status": result["publication_status"],
+                "lastExecutedTime": None,
             }
         )
 
@@ -35,4 +36,12 @@ def test_put_get_delete_update():
             Key={"id": "abc123"},
             UpdateExpression="SET keyword = :keyword",
             ExpressionAttributeValues={":keyword": "kw2"},
+        )
+
+        # update_last_executed_time_by_id: update_item呼び出し
+        repo.update_last_executed_time_by_id("abc123", "2024-06-13T12:34:56+09:00")
+        mock_table.update_item.assert_called_with(
+            Key={"id": "abc123"},
+            UpdateExpression="SET lastExecutedTime = :lastExecutedTime",
+            ExpressionAttributeValues={":lastExecutedTime": "2024-06-13T12:34:56+09:00"},
         )

--- a/tests/repositories/test_settings_repository.py
+++ b/tests/repositories/test_settings_repository.py
@@ -43,5 +43,7 @@ def test_put_get_delete_update():
         mock_table.update_item.assert_called_with(
             Key={"id": "abc123"},
             UpdateExpression="SET lastExecutedTime = :lastExecutedTime",
-            ExpressionAttributeValues={":lastExecutedTime": "2024-06-13T12:34:56+09:00"},
+            ExpressionAttributeValues={
+                ":lastExecutedTime": "2024-06-13T12:34:56+09:00"
+            },
         )


### PR DESCRIPTION
- TweetWacherSettingsTableにlastExecutedTimeカラムを追加し、ISO8601形式で保存するように
- REST APIの一覧取得でlastExecutedTimeをJSTで人が見やすい形で返すように
- バッチ処理で正常終了時にlastExecutedTimeを現在時刻（JST, ISO8601）で保存するように
- バッチ処理時、アクティブ設定をlastExecutedTimeがnull→古い順でソートして処理するように
- 各種テストも追加・修正済み

ご確認よろしくお願いします。